### PR TITLE
Fix lineno after include directive

### DIFF
--- a/src/cpp/pp_parser.c
+++ b/src/cpp/pp_parser.c
@@ -115,6 +115,7 @@ Token *pp_match(enum TokenKind kind) {
         break;
 
       const char *comment_start = q;
+      q += 2;
       for (;;) {
         q = block_comment_end(q);
         if (q != NULL) {

--- a/src/cpp/pp_parser.h
+++ b/src/cpp/pp_parser.h
@@ -20,6 +20,7 @@ Stream *set_pp_stream(Stream *stream);
 PpResult pp_expr(void);
 Vector *pp_funargs(void);
 
+Token *pp_match(enum TokenKind kind);
 Token *pp_consume(enum TokenKind kind, const char *error);
 
 void pp_parse_error(const Token *token, const char *fmt, ...);

--- a/tests/cpptest.sh
+++ b/tests/cpptest.sh
@@ -61,7 +61,7 @@ compile_error() {
   local title="$1"
   local input="$2"
 
-  echo -n "$title => "
+  echo -n "Error case: $title => "
 
   echo -e "$input" | $CPP | tr -d '\n'
   local result="$?"
@@ -128,3 +128,8 @@ compile_error 'Duplicate #else' '#if 0\n#else\n#else\n#endif'
 # Include with macro
 echo "#define FOO (37)" > tmp.h
 try_run 'Include with macro' 37 "#define FILE  \"tmp.h\"\n#include FILE\nint main(){return FOO;}" tmp.c
+
+# Block comment after include
+echo "#define FOO (73)" > tmp.h
+try_run 'Comment after include' 73 "#include \"tmp.h\" /*block\n*/ // line\nint main(){return FOO;}" tmp.c
+compile_error 'Token after include comment' "#include \"tmp.h\" /*block\n*/ illegal-token\nint main(){return FOO;}" tmp.c


### PR DESCRIPTION
Hi @mingodad , would you please take a look this PR?
This fix lineno with `#include`: https://github.com/tyfkda/xcc/issues/85#issuecomment-1230123862
Thanks!

Extra new line was put after `include`.