### PR TITLE
fix bug when using more than 64 function pointers

### DIFF
--- a/src/wcc/gen_wasm.c
+++ b/src/wcc/gen_wasm.c
@@ -519,7 +519,7 @@ static void gen_lval(Expr *expr, bool needval) {
         if (varinfo->type->kind == TY_FUNC) {
           uint32_t indirect_func = get_indirect_function_index(expr->var.name);
           ADD_CODE(OP_I32_CONST);
-          ADD_ULEB128(indirect_func);
+          ADD_LEB128(indirect_func);
         } else {
           GVarInfo *info = get_gvar_info(expr);
           ADD_CODE(OP_I32_CONST);


### PR DESCRIPTION
Example program showing the bug:

~~~ C
#include <stdio.h>

void f00(void) { } void f01(void) { } void f02(void) { } void f03(void) { } void f04(void) { } void f05(void) { } void f06(void) { } void f07(void) { }
void f08(void) { } void f09(void) { } void f0A(void) { } void f0B(void) { } void f0C(void) { } void f0D(void) { } void f0E(void) { } void f0F(void) { }

void f10(void) { } void f11(void) { } void f12(void) { } void f13(void) { } void f14(void) { } void f15(void) { } void f16(void) { } void f17(void) { }
void f18(void) { } void f19(void) { } void f1A(void) { } void f1B(void) { } void f1C(void) { } void f1D(void) { } void f1E(void) { } void f1F(void) { }

void f20(void) { } void f21(void) { } void f22(void) { } void f23(void) { } void f24(void) { } void f25(void) { } void f26(void) { } void f27(void) { }
void f28(void) { } void f29(void) { } void f2A(void) { } void f2B(void) { } void f2C(void) { } void f2D(void) { } void f2E(void) { } void f2F(void) { }

void f30(void) { } void f31(void) { } void f32(void) { } void f33(void) { } void f34(void) { } void f35(void) { } void f36(void) { } void f37(void) { }
void f38(void) { } void f39(void) { } void f3A(void) { } void f3B(void) { } void f3C(void) { } void f3D(void) { } void f3E(void) { } void f3F(void) { }

void f40(void) { } void f41(void) { } void f42(void) { } void f43(void) { } void f44(void) { } void f45(void) { } void f46(void) { } void f47(void) { }
void f48(void) { } void f49(void) { } void f4A(void) { } void f4B(void) { } void f4C(void) { } void f4D(void) { } void f4E(void) { } void f4F(void) { }

int main(void)
{
	void (*f[])(void) =
	{
		&f00, &f01, &f02, &f03, &f04, &f05, &f06, &f07, &f08, &f09, &f0A, &f0B, &f0C, &f0D, &f0E, &f0F,
		&f10, &f11, &f12, &f13, &f14, &f15, &f16, &f17, &f18, &f19, &f1A, &f1B, &f1C, &f1D, &f1E, &f1F,
		&f20, &f21, &f22, &f23, &f24, &f25, &f26, &f27, &f28, &f29, &f2A, &f2B, &f2C, &f2D, &f2E, &f2F,
		&f30, &f31, &f32, &f33, &f34, &f35, &f36, &f37, &f38, &f39, &f3A, &f3B, &f3C, &f3D, &f3E, &f3F,
		&f40, &f41, &f42, &f43, &f44, &f45, &f46, &f47, &f48, &f49, &f4A, &f4B, &f4C, &f4D, &f4E, &f4F,
	};
	
	for (int i = 0 ; i < sizeof f / sizeof *f ; i++)
		printf("%d: %lld\n", i, (long long int)f[i]);
	
	return 0;
}
~~~