### PR TITLE
Fix compilation error

### DIFF
--- a/src/cc/parser_expr.c
+++ b/src/cc/parser_expr.c
@@ -508,7 +508,7 @@ Expr *extract_bitfield_value(Expr *src, const MemberInfo *minfo) {
     tmp = new_expr_bop(EX_BITAND, tmp->type, tmp->token, tmp, new_expr_fixlit(tmp->type, tmp->token, mask));
   } else {
 #if defined(__aarch64__) || defined(__WASM) || defined(TARGET_WASM)
-    const int MINREGSIZE = 4;
+    const unsigned int MINREGSIZE = 4;
     int w = MAX(type_size(type), MINREGSIZE) * TARGET_CHAR_BIT;
 #else
     int w = type_size(type) * TARGET_CHAR_BIT;


### PR DESCRIPTION
When running the tests it came up with this comparison error

```
cc -ansi -std=c11 -pedantic -MMD -Wall -Wextra -Werror -Wold-style-definition -Wno-missing-field-initializers -Wno-empty-body -D_DEFAULT_SOURCE -O2 -g3 -Isrc/cc -Isrc/as
 -Isrc/util -Isrc/cc/arch/x64 -DTARGET_WASM -c -o obj/wcc/parser_expr.o src/cc/parser_expr.c                                                                             
In file included from src/cc/parser_expr.c:15:0:                                                                                                                         
src/cc/parser_expr.c: In function ‘extract_bitfield_value’:                                                                                                              
src/util/util.h:12:25: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]                                                          
 #define MAX(a, b)  ((a) > (b) ? (a) : (b))                                                                                                                              
                         ^                                                                                                                                               
src/cc/parser_expr.c:512:13: note: in expansion of macro ‘MAX’                                                                                             
     int w = MAX(type_size(type), MINREGSIZE) * TARGET_CHAR_BIT;                                                                                                         
             ^~~                                                                                                                                               
src/util/util.h:12:37: error: signed and unsigned type in conditional expression [-Werror=sign-compare]                                                                  
 #define MAX(a, b)  ((a) > (b) ? (a) : (b))                                                                                                                             
                                     ^                                                                                                                                   
src/cc/parser_expr.c:512:13: note: in expansion of macro ‘MAX’                                                                                                           
     int w = MAX(type_size(type), MINREGSIZE) * TARGET_CHAR_BIT;                                                                                                         
             ^~~                                                                                                                                                         
cc1: all warnings being treated as errors
```