### PR TITLE
feat: Win32 compatibility for wcc (MinGW64 MSYS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ Compile C to WebAssembly/WASI binary.
   * node.js
   * `llvm-ar`
 
+Install NodeJS dependencies:
+```sh
+npm install
+```
+
+##### MinGW-w64 (Windows)
+
+Install dependencies:
+```sh
+pacman -S llvm mingw64/mingw-w64-x86_64-nodejs
+```
+
 #### Build
 
 ```sh

--- a/src/ar/ar.h
+++ b/src/ar/ar.h
@@ -1,0 +1,66 @@
+/*	$OpenBSD: ar.h,v 1.3 2003/06/02 19:34:12 millert Exp $	*/
+/*	$NetBSD: ar.h,v 1.4 1994/10/26 00:55:43 cgd Exp $	*/
+
+/*-
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Hugh Smith at The University of Guelph.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)ar.h	8.2 (Berkeley) 1/21/94
+ */
+
+#ifndef _AR_H_
+#define	_AR_H_
+
+/* Pre-4BSD archives had these magic numbers in them. */
+#define	OARMAG1	0177555
+#define	OARMAG2	0177545
+
+#define	ARMAG		"!<arch>\n"	/* ar "magic number" */
+#define	SARMAG		8		/* strlen(ARMAG); */
+
+#define	AR_EFMT1	"#1/"		/* extended format #1 */
+
+struct ar_hdr {
+	char ar_name[16];		/* name */
+	char ar_date[12];		/* modification time */
+	char ar_uid[6];			/* user id */
+	char ar_gid[6];			/* group id */
+	char ar_mode[8];		/* octal file permissions */
+	char ar_size[10];		/* size in bytes */
+#define	ARFMAG	"`\n"
+	char ar_fmag[2];		/* consistency check */
+};
+
+#endif /* !_AR_H_ */

--- a/src/as/arch/riscv64/asm_code.c
+++ b/src/as/arch/riscv64/asm_code.c
@@ -24,11 +24,11 @@ void make_code32(Inst *inst, Code *code, unsigned int *buf, int len) {
 }
 
 inline bool is_im6(int64_t x) {
-  return x <= ((1L << 5) - 1) && x >= -(1L << 5);
+  return x <= ((1LL << 5) - 1) && x >= -(1LL << 5);
 }
 
 inline bool is_im12(int64_t x) {
-  return x <= ((1L << 11) - 1) && x >= -(1L << 11);
+  return x <= ((1LL << 11) - 1) && x >= -(1LL << 11);
 }
 
 inline bool assemble_error(const ParseInfo *info, const char *message) {

--- a/src/as/arch/x64/asm_code.c
+++ b/src/as/arch/x64/asm_code.c
@@ -135,7 +135,7 @@ static unsigned char *asm_mov_imr(Inst *inst, Code *code) {
 
 static unsigned char *asm_mov_ir(Inst *inst, Code *code) {
   if (inst->src.indirect.offset->kind == EX_FIXNUM) {
-    long offset = inst->src.indirect.offset->fixnum;
+    long long offset = inst->src.indirect.offset->fixnum;
     enum RegSize size = inst->dst.reg.size;
     if (inst->src.indirect.reg.no != RIP) {
       int sno = opr_regno(&inst->src.indirect.reg);
@@ -167,7 +167,7 @@ static unsigned char *asm_mov_ir(Inst *inst, Code *code) {
 
 static unsigned char *asm_mov_ri(Inst *inst, Code *code) {
   if (inst->dst.indirect.offset->kind == EX_FIXNUM) {
-    long offset = inst->dst.indirect.offset->fixnum;
+    long long offset = inst->dst.indirect.offset->fixnum;
     enum RegSize size = inst->src.reg.size;
     if (inst->dst.indirect.reg.no != RIP) {
       int sno = opr_regno(&inst->src.reg);
@@ -199,7 +199,7 @@ static unsigned char *asm_mov_ri(Inst *inst, Code *code) {
 
 static unsigned char *asm_mov_iir(Inst *inst, Code *code) {
   if (inst->src.indirect_with_index.offset->kind == EX_FIXNUM) {
-    long offset = inst->src.indirect_with_index.offset->fixnum;
+    long long offset = inst->src.indirect_with_index.offset->fixnum;
     assert(is_im32(offset));
     short offset_bit = offset == 0 ? 0x04 : is_im8(offset) ? 0x44 : 0x84;
     enum RegSize size = inst->dst.reg.size;
@@ -288,7 +288,7 @@ static unsigned char *asm_mov_sr(Inst *inst, Code *code) {
 }
 
 static unsigned char *asm_movbwlq_imi(Inst *inst, Code *code) {
-  long offset = inst->dst.indirect.offset->fixnum;
+  long long offset = inst->dst.indirect.offset->fixnum;
   unsigned char sno = 0;
   unsigned char dno = opr_regno(&inst->dst.indirect.reg);
   unsigned char op = (offset == 0 && (dno & 7) != RBP - RAX) ? 0x00 : is_im8(offset) ? (unsigned char)0x40 : (unsigned char)0x80;
@@ -311,7 +311,7 @@ static unsigned char *asm_movbwlq_imi(Inst *inst, Code *code) {
     p += 4;
   }
 
-  long value = inst->src.immediate;
+  long long value = inst->src.immediate;
   switch (inst->op) {
   case MOVB: *p++ = IM8(value); break;
   case MOVW: PUT_CODE(p, IM16(value)); p += 2; break;
@@ -341,7 +341,7 @@ static unsigned char *asm_movbwlq_imd(Inst *inst, Code *code) {
   PUT_CODE(p, IM32(dst));
   p += 4;
 
-  long value = inst->src.immediate;
+  long long value = inst->src.immediate;
   switch (inst->op) {
   case MOVB: *p++ = IM8(value); break;
   case MOVW: PUT_CODE(p, IM16(value)); p += 2; break;
@@ -441,7 +441,7 @@ static unsigned char *asm_movsd_xx(Inst *inst, Code *code) { return asm_movsds_x
 static unsigned char *asm_movss_xx(Inst *inst, Code *code) { return asm_movsds_xx(inst, code, true); }
 
 static unsigned char *asm_movsds_ix(Inst *inst, Code *code, bool single) {
-  long offset;
+  long long offset;
   if (inst->src.indirect.offset->kind == EX_FIXNUM &&
       (offset = inst->src.indirect.offset->fixnum, is_im32(offset))) {
     if (inst->src.indirect.reg.no != RIP) {
@@ -482,7 +482,7 @@ static unsigned char *asm_movsd_ix(Inst *inst, Code *code) { return asm_movsds_i
 static unsigned char *asm_movss_ix(Inst *inst, Code *code) { return asm_movsds_ix(inst, code, true); }
 
 static unsigned char *asm_movsds_xi(Inst *inst, Code *code, bool single) {
-  long offset;
+  long long offset;
   if (inst->dst.indirect.offset->kind == EX_FIXNUM &&
       (offset = inst->dst.indirect.offset->fixnum, is_im32(offset))) {
     if (inst->dst.indirect.reg.no != RIP) {
@@ -661,7 +661,7 @@ static unsigned char *asm_sqrtsd_xx(Inst *inst, Code *code) {
   return p;
 }
 
-static long signed_immediate(long value, enum RegSize size) {
+static long long signed_immediate(long long value, enum RegSize size) {
   switch (size) {
   case REG8:   return (int8_t)value;
   case REG16:  return (int16_t)value;
@@ -677,7 +677,7 @@ static unsigned char *asm_lea_ir(Inst *inst, Code *code) {
   unsigned char *p = code->buf;
   if (inst->src.indirect.reg.no != RIP) {
     if (inst->src.indirect.offset->kind == EX_FIXNUM) {
-      long offset = inst->src.indirect.offset->fixnum;
+      long long offset = inst->src.indirect.offset->fixnum;
       enum RegSize size = inst->dst.reg.size;
       short buf[] = {
         MAKE_REX_INDIRECT(
@@ -706,8 +706,8 @@ static unsigned char *asm_lea_iir(Inst *inst, Code *code) {
   Expr *scale_expr = inst->src.indirect_with_index.scale;
   if ((offset_expr == NULL || offset_expr->kind == EX_FIXNUM) &&
       (scale_expr == NULL || scale_expr->kind == EX_FIXNUM)) {
-    long offset = offset_expr != NULL ? offset_expr->fixnum : 0;
-    long scale = scale_expr != NULL ? scale_expr->fixnum : 1;
+    long long offset = offset_expr != NULL ? offset_expr->fixnum : 0;
+    long long scale = scale_expr != NULL ? scale_expr->fixnum : 1;
     if (is_im32(offset) && 1 <= scale && scale <= 8 && IS_POWER_OF_2(scale)) {
       int breg = opr_regno(&inst->src.indirect_with_index.base_reg);
       int ireg = opr_regno(&inst->src.indirect_with_index.index_reg);
@@ -746,7 +746,7 @@ static unsigned char *asm_add_rr(Inst *inst, Code *code) {
 }
 
 static unsigned char *asm_add_imr(Inst *inst, Code *code) {
-  long value = inst->src.immediate;
+  long long value = inst->src.immediate;
   if (is_im32(value)) {
     bool im8 = is_im8(value);
     enum RegSize size = inst->dst.reg.size;
@@ -777,7 +777,7 @@ static unsigned char *asm_add_imr(Inst *inst, Code *code) {
 
 static unsigned char *asm_add_ir(Inst *inst, Code *code) {
   if (inst->src.indirect.offset->kind == EX_FIXNUM && inst->src.indirect.reg.no != RIP) {
-    long offset = inst->src.indirect.offset->fixnum;
+    long long offset = inst->src.indirect.offset->fixnum;
     enum RegSize size = inst->dst.reg.size;
     unsigned char *p = code->buf;
     short buf[] = {
@@ -820,9 +820,9 @@ static unsigned char *asm_add_iir(Inst *inst, Code *code) {
 
 static unsigned char *asm_addq_imi(Inst *inst, Code *code) {
   if (inst->dst.indirect.offset->kind == EX_FIXNUM) {
-    long value = inst->src.immediate;
+    long long value = inst->src.immediate;
     if (is_im32(value)) {
-      long offset = inst->dst.indirect.offset->fixnum;
+      long long offset = inst->dst.indirect.offset->fixnum;
       unsigned char sno = 0;
       unsigned char dno = opr_regno(&inst->dst.indirect.reg);
       unsigned char op = (offset == 0 && (dno & 7) != RBP - RAX) ? 0x00 : is_im8(offset) ? (unsigned char)0x40 : (unsigned char)0x80;
@@ -864,7 +864,7 @@ static unsigned char *asm_sub_rr(Inst *inst, Code *code) {
 }
 
 static unsigned char *asm_sub_imr(Inst *inst, Code *code) {
-  long value = inst->src.immediate;
+  long long value = inst->src.immediate;
   if (is_im32(value)) {
     bool im8 = is_im8(value);
     enum RegSize size = inst->dst.reg.size;
@@ -895,7 +895,7 @@ static unsigned char *asm_sub_imr(Inst *inst, Code *code) {
 
 static unsigned char *asm_sub_ir(Inst *inst, Code *code) {
   if (inst->src.indirect.offset->kind == EX_FIXNUM && inst->src.indirect.reg.no != RIP) {
-    long offset = inst->src.indirect.offset->fixnum;
+    long long offset = inst->src.indirect.offset->fixnum;
     enum RegSize size = inst->dst.reg.size;
     unsigned char *p = code->buf;
     short buf[] = {
@@ -938,9 +938,9 @@ static unsigned char *asm_sub_iir(Inst *inst, Code *code) {
 
 static unsigned char *asm_subq_imi(Inst *inst, Code *code) {
   if (inst->dst.indirect.offset->kind == EX_FIXNUM) {
-    long value = inst->src.immediate;
+    long long value = inst->src.immediate;
     if (is_im32(value)) {
-      long offset = inst->dst.indirect.offset->fixnum;
+      long long offset = inst->dst.indirect.offset->fixnum;
       unsigned char sno = 0;
       unsigned char dno = opr_regno(&inst->dst.indirect.reg);
       unsigned char op = (offset == 0 && (dno & 7) != RBP - RAX) ? 0x28 : is_im8(offset) ? (unsigned char)0x40 : (unsigned char)0x80;
@@ -1036,7 +1036,7 @@ static unsigned char *asm_inc_r(Inst *inst, Code *code) {
 static unsigned char *asm_incbwlq_i(Inst *inst, Code *code) {
   if (inst->src.indirect.reg.no != RIP) {
     enum RegSize size = inst->op + (REG8 - INCB);
-    long offset = inst->src.indirect.offset->fixnum;
+    long long offset = inst->src.indirect.offset->fixnum;
     unsigned char *p = code->buf;
     short buf[] = {
       MAKE_REX_INDIRECT(
@@ -1061,7 +1061,7 @@ static unsigned char *asm_dec_r(Inst *inst, Code *code) {
 static unsigned char *asm_decbwlq_i(Inst *inst, Code *code) {
   if (inst->src.indirect.reg.no != RIP) {
     enum RegSize size = inst->op + (REG8 - DECB);
-    long offset = inst->src.indirect.offset->fixnum;
+    long long offset = inst->src.indirect.offset->fixnum;
     unsigned char *p = code->buf;
     short buf[] = {
       MAKE_REX_INDIRECT(
@@ -1085,7 +1085,7 @@ static unsigned char *asm_and_rr(Inst *inst, Code *code) {
 }
 
 static unsigned char *asm_and_imr(Inst *inst, Code *code) {
-  long value = inst->src.immediate;
+  long long value = inst->src.immediate;
   enum RegSize size = inst->dst.reg.size;
   unsigned char *p = code->buf;
   if (is_im8(value) && (size != REG8 || opr_regno(&inst->dst.reg) != AL - AL)) {
@@ -1127,7 +1127,7 @@ static unsigned char *asm_or_rr(Inst *inst, Code *code) {
 }
 
 static unsigned char *asm_or_imr(Inst *inst, Code *code) {
-  long value = inst->src.immediate;
+  long long value = inst->src.immediate;
   enum RegSize size = inst->dst.reg.size;
   unsigned char *p = code->buf;
   if (is_im8(value) && (size != REG8 || opr_regno(&inst->dst.reg) != AL - AL)) {
@@ -1168,7 +1168,7 @@ static unsigned char *asm_xor_rr(Inst *inst, Code *code) {
 }
 
 static unsigned char *asm_xor_imr(Inst *inst, Code *code) {
-  long value = inst->src.immediate;
+  long long value = inst->src.immediate;
   enum RegSize size = inst->dst.reg.size;
   unsigned char *p = code->buf;
   if (is_im8(value) && (size != REG8 || opr_regno(&inst->dst.reg) != AL - AL)) {
@@ -1276,7 +1276,7 @@ static unsigned char *asm_cmp_rr(Inst *inst, Code *code) {
 
 static unsigned char *asm_cmp_imr(Inst *inst, Code *code) {
   enum RegSize size = inst->dst.reg.size;
-  long value = signed_immediate(inst->src.immediate, size);
+  long long value = signed_immediate(inst->src.immediate, size);
   if (is_im32(value) || size <= REG32) {
     bool im8 = is_im8(value);
     int d = opr_regno(&inst->dst.reg);
@@ -1352,7 +1352,7 @@ static unsigned char *asm_push_r(Inst *inst, Code *code) {
 
 static unsigned char *asm_push_im(Inst *inst, Code *code) {
   unsigned char *p = code->buf;
-  long value = inst->src.immediate;
+  long long value = inst->src.immediate;
   if (is_im8(value)) {
     *p++ = 0x6a;
     *p++ = IM8(value);
@@ -1396,7 +1396,7 @@ static unsigned char *asm_jmp_der(Inst *inst, Code *code) {
 static unsigned char *asm_jmp_dei(Inst *inst, Code *code) {
   Expr *offset_expr = inst->src.indirect.offset;
   if ((offset_expr == NULL || offset_expr->kind == EX_FIXNUM)) {
-    long offset = offset_expr != NULL ? offset_expr->fixnum : 0;
+    long long offset = offset_expr != NULL ? offset_expr->fixnum : 0;
     if (is_im32(offset)) {
       short offset_bit = offset == 0 ? 0x20 : is_im8(offset) ? 0x60 : 0xa0;
       short b = inst->src.indirect.reg.no;
@@ -1425,8 +1425,8 @@ static unsigned char *asm_jmp_deii(Inst *inst, Code *code) {
   Expr *scale_expr = inst->src.indirect_with_index.scale;
   if ((offset_expr == NULL || offset_expr->kind == EX_FIXNUM) &&
       (scale_expr == NULL || scale_expr->kind == EX_FIXNUM)) {
-    long offset = offset_expr != NULL ? offset_expr->fixnum : 0;
-    long scale = scale_expr != NULL ? scale_expr->fixnum : 1;
+    long long offset = offset_expr != NULL ? offset_expr->fixnum : 0;
+    long long scale = scale_expr != NULL ? scale_expr->fixnum : 1;
     if (is_im32(offset) && 1 <= scale && scale <= 8 && IS_POWER_OF_2(scale)) {
       short b = inst->src.indirect_with_index.base_reg.no;
       short scale_bit = kPow2Table[scale];
@@ -1481,7 +1481,7 @@ static unsigned char *asm_ret(Inst *inst, Code *code) {
 }
 
 static unsigned char *asm_int_im(Inst *inst, Code *code) {
-  long value = inst->src.immediate;
+  long long value = inst->src.immediate;
   MAKE_CODE(inst, code, 0xcd, IM8(value));
   return code->buf;
 }

--- a/src/as/as.c
+++ b/src/as/as.c
@@ -2,7 +2,6 @@
 
 #include <assert.h>
 #include <ctype.h>
-#include <stdint.h>  // uintptr_t
 #include <stdio.h>
 #include <string.h>
 #include <strings.h>  // strncasecmp
@@ -68,7 +67,7 @@ static void drop_all(FILE *fp) {
   }
 }
 
-static void putnum(FILE *fp, unsigned long num, int bytes) {
+static void putnum(FILE *fp, size_t num, int bytes) {
   for (int i = 0; i < bytes; ++i) {
     fputc(num, fp);
     num >>= 8;

--- a/src/as/as.c
+++ b/src/as/as.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <strings.h>  // strncasecmp
 #include <sys/stat.h>
-#include <unistd.h>
+#include <unistd.h> // isatty
 
 #include "asm_code.h"
 #include "elfutil.h"
@@ -129,7 +129,7 @@ static int output_obj(const char *ofn, Table *label_table, Vector *unresolved) {
         continue;
       }
       sym = symtab_add(symtabs[bind], name);
-      int type;
+      int type = 0;
       switch (info->kind) {
       case LK_NONE:    type = STT_NOTYPE; break;
       case LK_FUNC:    type = STT_FUNC; break;

--- a/src/as/ir_asm.h
+++ b/src/as/ir_asm.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include <stddef.h>  // size_t
-#include <stdint.h>  // uintptr_t
+#include <stdint.h>  // uintptr_t, intptr_t
 
 #include "asm_code.h"  // Code
 

--- a/src/cc/arch/aarch64/emit_code.c
+++ b/src/cc/arch/aarch64/emit_code.c
@@ -207,7 +207,7 @@ static void emit_defun(Function *func) {
   size_t frame_size = ALIGN(fnbe->frame_size, 16);
   bool fp_saved = false;  // Frame pointer saved?
   bool lr_saved = false;  // Link register saved?
-  unsigned long used_reg_bits = fnbe->ra->used_reg_bits;
+  uint64_t used_reg_bits = fnbe->ra->used_reg_bits;
   if (!no_stmt) {
     fp_saved = frame_size > 0 || fnbe->ra->flag & RAF_STACK_FRAME;
     lr_saved = (func->flag & FUNCF_HAS_FUNCALL) != 0;
@@ -217,7 +217,7 @@ static void emit_defun(Function *func) {
       STP(FP, LR, PRE_INDEX(SP, -16));
 
       // FP is saved, so omit from callee save.
-      used_reg_bits &= ~(1UL << GET_FPREG_INDEX());
+      used_reg_bits &= ~(1ULL << GET_FPREG_INDEX());
     }
 
     // Callee save.

--- a/src/cc/arch/riscv64/emit_code.c
+++ b/src/cc/arch/riscv64/emit_code.c
@@ -167,7 +167,7 @@ static void emit_defun(Function *func) {
   size_t frame_size = ALIGN(fnbe->frame_size, 16);
   bool fp_saved = false;  // Frame pointer saved?
   bool ra_saved = false;  // Return Address register saved?
-  unsigned long used_reg_bits = fnbe->ra->used_reg_bits;
+  uint64_t used_reg_bits = fnbe->ra->used_reg_bits;
   int vaarg_params_saved = 0;
   if (!no_stmt) {
     if (func->type->func.vaargs) {
@@ -187,7 +187,7 @@ static void emit_defun(Function *func) {
       SD(FP, IMMEDIATE_OFFSET0(SP));
 
       // FP is saved, so omit from callee save.
-      used_reg_bits &= ~(1UL << GET_FPREG_INDEX());
+      used_reg_bits &= ~(1ULL << GET_FPREG_INDEX());
     }
 
     // Callee save.

--- a/src/cc/arch/x64/emit_code.c
+++ b/src/cc/arch/x64/emit_code.c
@@ -19,7 +19,7 @@
 #include "var.h"
 #include "x64.h"
 
-int count_callee_save_regs(unsigned long used, unsigned long fused);
+int count_callee_save_regs(uint64_t used, uint64_t fused);
 
 char *im(int64_t x) {
   return fmt("$%" PRId64, x);

--- a/src/cc/backend/codegen.c
+++ b/src/cc/backend/codegen.c
@@ -708,7 +708,7 @@ void map_virtual_to_physical_registers(RegAlloc *ra) {
 // Detect living registers for each instruction.
 void detect_living_registers(RegAlloc *ra, BBContainer *bbcon) {
   int maxbit = ra->settings->phys_max + ra->settings->fphys_max;
-  unsigned long living_pregs = 0;
+  uint64_t living_pregs = 0;
   assert((int)sizeof(living_pregs) * CHAR_BIT >= maxbit);
   LiveInterval **livings = ALLOCA(sizeof(*livings) * maxbit);
   for (int i = 0; i < maxbit; ++i)
@@ -726,7 +726,7 @@ void detect_living_registers(RegAlloc *ra, BBContainer *bbcon) {
     if (li->state != LI_NORMAL || VREGFOR(li, ra) == NULL)
       continue;
     int bitno = BITNO(li, ra);
-    living_pregs |= 1UL << bitno;
+    living_pregs |= 1ULL << bitno;
     livings[bitno] = li;
   }
 
@@ -739,7 +739,7 @@ void detect_living_registers(RegAlloc *ra, BBContainer *bbcon) {
         LiveInterval *li = livings[k];
         if (li != NULL && nip == li->end) {
           assert(BITNO(li, ra) == k);
-          living_pregs &= ~(1UL << k);
+          living_pregs &= ~(1ULL << k);
           livings[k] = NULL;
         }
       }
@@ -762,7 +762,7 @@ void detect_living_registers(RegAlloc *ra, BBContainer *bbcon) {
         if (nip == li->start) {
           assert(VREGFOR(li, ra) != NULL);
           int bitno = BITNO(li, ra);
-          living_pregs |= 1UL << bitno;
+          living_pregs |= 1ULL << bitno;
           livings[bitno] = li;
         }
       }

--- a/src/cc/backend/codegen_expr.c
+++ b/src/cc/backend/codegen_expr.c
@@ -175,14 +175,14 @@ static VReg *gen_cast(Expr *expr) {
       is_fixnum(dst_type->kind) && dst_type->fixnum.is_unsigned && dst_size >= 8) {
     // Transform from (uint64_t)flonum
     //   to: (flonum <= INT64_MAX) ? (int64_t)flonum
-    //                             : ((int64_t)(flonum - (INT64_MAX + 1UL)) ^ (1L << 63))
+    //                             : ((int64_t)(flonum - (INT64_MAX + 1ULL)) ^ (1LL << 63))
     const Token *token = expr->token;
     Type *i64t = get_fixnum_type_from_size(dst_size);
     Expr *cond = new_expr_bop(EX_LE, &tyBool, token, src,
                               new_expr_flolit(src->type, src->token, INT64_MAX));
     Expr *offsetted = new_expr_addsub(
         EX_SUB, token, src,
-        new_expr_flolit(src->type, src->token, (uint64_t)INT64_MAX + 1UL));
+        new_expr_flolit(src->type, src->token, (uint64_t)INT64_MAX + 1ULL));
     Expr *xorred = new_expr_bop(EX_BITXOR, i64t, token, make_cast(i64t, token, offsetted, false),
                                 new_expr_fixlit(i64t, token, (uint64_t)1 << 63));
     Expr *ternary = new_expr_ternary(token, cond, make_cast(i64t, token, src, false), xorred, i64t);
@@ -206,7 +206,7 @@ static VReg *gen_cast(Expr *expr) {
     if (dst_size < (1 << vreg->vsize) && dst_size < (int)sizeof(Fixnum)) {
       // Assume that integer is represented in Two's complement
       size_t bit = dst_size * TARGET_CHAR_BIT;
-      UFixnum mask = (-1UL) << bit;
+      UFixnum mask = (-1ULL) << bit;
       if (!is_unsigned(dst_type) && (value & (1 << (bit - 1))))    // signed && negative
         value |= mask;
       else

--- a/src/cc/backend/ir.h
+++ b/src/cc/backend/ir.h
@@ -150,7 +150,7 @@ typedef struct IR {
       int arg_count;
       int stack_args_size;
       int stack_aligned;
-      unsigned long living_pregs;
+      uint64_t living_pregs;
       Vector *caller_saves;  // <const char*>
     } precall;
     struct {
@@ -232,8 +232,8 @@ typedef struct BBContainer {
 BBContainer *new_func_blocks(void);
 void detect_from_bbs(BBContainer *bbcon);
 void analyze_reg_flow(BBContainer *bbcon);
-int push_callee_save_regs(unsigned long used, unsigned long fused);
-void pop_callee_save_regs(unsigned long used, unsigned long fused);
+int push_callee_save_regs(uint64_t used, uint64_t fused);
+void pop_callee_save_regs(uint64_t used, uint64_t fused);
 
 void emit_bb_irs(BBContainer *bbcon);
 

--- a/src/cc/backend/regalloc.h
+++ b/src/cc/backend/regalloc.h
@@ -19,7 +19,7 @@ enum LiveIntervalState {
 };
 
 typedef struct LiveInterval {
-  unsigned long occupied_reg_bit;  // Represent occupied registers in bit.
+  uint64_t occupied_reg_bit;  // Represent occupied registers in bit.
   enum LiveIntervalState state;
   int start;
   int end;
@@ -28,7 +28,7 @@ typedef struct LiveInterval {
 } LiveInterval;
 
 typedef struct RegAllocSettings {
-  unsigned long (*detect_extra_occupied)(RegAlloc *ra, IR *ir);
+  uint64_t (*detect_extra_occupied)(RegAlloc *ra, IR *ir);
   const int *reg_param_mapping;
   int phys_max;              // Max physical register count.
   int phys_temporary_count;  // Temporary register count (= start index for saved registers)
@@ -45,8 +45,8 @@ typedef struct RegAlloc {
   LiveInterval *intervals;  // size=vregs->len
   LiveInterval **sorted_intervals;
 
-  unsigned long used_reg_bits;
-  unsigned long used_freg_bits;
+  uint64_t used_reg_bits;
+  uint64_t used_freg_bits;
   int flag;
 } RegAlloc;
 

--- a/src/cc/builtin.c
+++ b/src/cc/builtin.c
@@ -45,7 +45,7 @@ static Expr *proc_builtin_nan(const Token *ident) {
     parse_error(PE_NOFATAL, fmt->token, "String literal expected");
   }
 
-  const uint64_t MASK = (1UL << 52) - 1UL;
+  const uint64_t MASK = (1ULL << 52) - 1ULL;
   union { double d; uint64_t q; } u;
   u.d = NAN;
   u.q = (u.q & ~MASK) | (significand & MASK);

--- a/src/cc/frontend/fe_misc.c
+++ b/src/cc/frontend/fe_misc.c
@@ -317,7 +317,7 @@ const MemberInfo *search_from_anonymous(const Type *type, const Name *name, cons
     const MemberInfo *member = &sinfo->members[i];
     if (member->name != NULL) {
       if (equal_name(member->name, name)) {
-        vec_push(stack, (void*)(long)i);
+        vec_push(stack, (void*)(long long)i);
         return member;
       }
     } else if (member->type->kind == TY_STRUCT) {

--- a/src/cc/frontend/lexer.c
+++ b/src/cc/frontend/lexer.c
@@ -616,8 +616,8 @@ static void *convert_str_to_wstr(const char *src, size_t *plen) {
       break;
   }
 
-  wchar_t *wstr = malloc_or_die(len * sizeof(*wstr));
-  wchar_t *q = wstr;
+  int *wstr = malloc_or_die(len * sizeof(*wstr));
+  int *q = wstr;
   for (const char *p = src;; ) {
     int c;
     p = read_utf8_char(p, &c);

--- a/src/cc/frontend/lexer.c
+++ b/src/cc/frontend/lexer.c
@@ -510,7 +510,7 @@ static Token *read_num(const char **pp) {
   if (tt == TK_INTLIT) {
     const int INT_BYTES = 4;  // TODO: Detect.
     int bits = INT_BYTES * TARGET_CHAR_BIT;
-    unsigned long long threshold = 1UL << (bits - (is_unsigned ? 0 : 1));
+    unsigned long long threshold = 1ULL << (bits - (is_unsigned ? 0 : 1));
     if (val >= threshold)
       tt = TK_LONGLIT;
   }

--- a/src/cc/frontend/parser_expr.c
+++ b/src/cc/frontend/parser_expr.c
@@ -855,7 +855,7 @@ static Expr *parse_prim(void) {
       {TK_ULONGLIT, FX_LONG, true},
       {TK_ULLONGLIT, FX_LLONG, true},
 #ifndef __NO_WCHAR
-      {TK_WCHARLIT, FX_INT, true},  // TODO: Must match with target's wchar_t
+      {TK_WCHARLIT, FX_INT, true},  // Uses 32-bit wchar_t internally
 #endif
     };
     for (int i = 0; i < (int)ARRAY_SIZE(TABLE); ++i) {

--- a/src/cc/frontend/parser_expr.c
+++ b/src/cc/frontend/parser_expr.c
@@ -145,7 +145,7 @@ static Expr *parse_member_access(Expr *target, Token *acctok) {
     Expr *p = target;
     Token *tok = acctok;
     for (int i = 0; i < stack->len; ++i) {
-      int index = (int)(long)stack->data[i];
+      int index = (int)(long long)stack->data[i];
       const MemberInfo *minfo = &type->struct_.info->members[index];
       type = qualified_type(minfo->type, type->qualifier);
       const Name *member_name = NULL;

--- a/src/config.h
+++ b/src/config.h
@@ -1,5 +1,21 @@
 #pragma once
 
+#ifdef _WIN32
+
+// 32-bit or 64-bit
+#if _WIN64
+#define __LP64__
+#else
+#define __ILP32__
+#endif
+
+#else // POSIX
+
+#define USE_ALLOCA
+
+#endif
+
+
 // Architecture
 #define XCC_ARCH_X64      1
 #define XCC_ARCH_AARCH64  2
@@ -44,8 +60,6 @@
 #  define NO_STD_LIB
 # endif
 #endif
-
-#define USE_ALLOCA
 
 #if defined(USE_ALLOCA)
 #include <alloca.h>

--- a/src/cpp/macro.c
+++ b/src/cpp/macro.c
@@ -1,7 +1,6 @@
 #include "../config.h"
 #include "macro.h"
 
-#include <alloca.h>
 #include <assert.h>
 #include <limits.h>  // INT_MAX
 #include <stdlib.h>  // malloc

--- a/src/cpp/pp_parser.h
+++ b/src/cpp/pp_parser.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <stdint.h>  // intptr_t
 #include <stdio.h>  // FILE
 
 #include "lexer.h"  // TokenKind, Token

--- a/src/ld/ld.c
+++ b/src/ld/ld.c
@@ -276,7 +276,7 @@ static void resolve_rela_elfobj(LinkEditor *ld, ElfObj *elfobj) {
       case R_RISCV_CALL:
         {
           int64_t offset = address - pc;
-          assert(offset < (1L << 19) && offset >= -(1L << 19));  // TODO
+          assert(offset < (1LL << 19) && offset >= -(1LL << 19));  // TODO
           *(uint32_t*)p = W_JAL(RA, offset);
         }
         break;
@@ -299,7 +299,7 @@ static void resolve_rela_elfobj(LinkEditor *ld, ElfObj *elfobj) {
       case R_RISCV_PCREL_HI20:
         {
           int64_t offset = address - pc;
-          assert(offset < (1L << 31) && offset >= -(1L << 31));
+          assert(offset < (1LL << 31) && offset >= -(1LL << 31));
           // const uint32_t MASK20 = (1U << 20) - 1;
           const uint32_t MASK12 = (1U << 12) - 1;
           if ((offset & MASK12) >= (1U << 11))
@@ -319,7 +319,7 @@ static void resolve_rela_elfobj(LinkEditor *ld, ElfObj *elfobj) {
           uintptr_t hipc = elfobj->section_infos[shdr->sh_info].progbits.address + hirela->r_offset;
 
           int64_t offset = hiaddress - hipc;
-          assert(offset < (1L << 31) && offset >= -(1L << 31));
+          assert(offset < (1LL << 31) && offset >= -(1LL << 31));
           const uint32_t MASK20 = (1U << 20) - 1;
           const uint32_t MASK12 = (1U << 12) - 1;
           *(uint32_t*)p = (*(uint32_t*)p & MASK20) | (((uint32_t)offset & MASK12) << 20);
@@ -328,7 +328,7 @@ static void resolve_rela_elfobj(LinkEditor *ld, ElfObj *elfobj) {
       case R_RISCV_RVC_JUMP:
         {
           int64_t offset = address - pc;
-          assert(offset < (1L << 11) && offset >= -(1L << 11));
+          assert(offset < (1LL << 11) && offset >= -(1LL << 11));
 
           uint16_t *q = (uint16_t*)p;
           assert((*q & 0xe003) == 0xa001);  // c.j
@@ -338,7 +338,7 @@ static void resolve_rela_elfobj(LinkEditor *ld, ElfObj *elfobj) {
       case R_RISCV_JAL:
         {
           int64_t offset = address - pc;
-          assert(offset < (1L << 19) && offset >= -(1L << 19));
+          assert(offset < (1LL << 19) && offset >= -(1LL << 19));
 
           uint32_t *q = (uint32_t*)p;
           assert((*q & 0x0000007f) == 0x6f);  // jal
@@ -663,7 +663,7 @@ static void dump_map_elfobj(LinkEditor *ld, ElfObj *elfobj, File *file, ArConten
       break;
     default: assert(false); break;
     }
-    fprintf(fp, "%9lx: %.*s  (%s", address, NAMES(name), file->filename);
+    fprintf(fp, "%9llx: %.*s  (%s", (unsigned long long)address, NAMES(name), file->filename);
     if (content != NULL)
       fprintf(fp, ", %s", content->name);
     fprintf(fp, ")\n");
@@ -770,11 +770,11 @@ int main(int argc, char *argv[]) {
       }
 
       fprintf(mapfp, "### Symbols\n");
-      fprintf(mapfp, "%9lx:  (start address)\n", (long)LOAD_ADDRESS);
+      fprintf(mapfp, "%9llx:  (start address)\n", (unsigned long long)LOAD_ADDRESS);
       dump_map_file(ld, mapfp);
 
       fprintf(mapfp, "\n### Entry point\n");
-      fprintf(mapfp, "%9lx: %.*s\n", entry_address, NAMES(entry_name));
+      fprintf(mapfp, "%9llx: %.*s\n", (unsigned long long)entry_address, NAMES(entry_name));
 
       if (mapfp != stdout)
         fclose(mapfp);

--- a/src/ld/ld.c
+++ b/src/ld/ld.c
@@ -1,6 +1,6 @@
 #include "../config.h"
 
-#include <ar.h>
+#include "../ar/ar.h"
 #include <assert.h>
 #include <fcntl.h>
 #include <stdbool.h>

--- a/src/util/archive.c
+++ b/src/util/archive.c
@@ -5,7 +5,7 @@
 #include <string.h>
 
 // https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=include/aout/ar.h;h=471a859fc57c7d8207193718610980f6bf2f83b3;hb=2cb5c79dad39dd438fb0f7372ac04cf5aa2a7db7
-#include <ar.h>
+#include "../ar/ar.h"
 
 #include "util.h"
 

--- a/src/util/elfutil.h
+++ b/src/util/elfutil.h
@@ -5,10 +5,10 @@
 #include <stdint.h>  // ssize_t
 #include <stdio.h>  // FILE
 
-#ifdef __APPLE__
-#include "../../include/elf.h"
-#else
+#if defined(__linux__)
 #include <elf.h>
+#else
+#include "../../include/elf.h"
 #endif
 
 #include "table.h"

--- a/src/util/gen_section.h
+++ b/src/util/gen_section.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <stddef.h>  // size_t
-#include <stdint.h>  // uintptr_t
 #include <stdio.h>   // FILE
+#include <stdint.h>  // uintptr_t, intptr_t
 
 #define SECTION_COUNT  (4)
 

--- a/src/util/getline.h
+++ b/src/util/getline.h
@@ -31,7 +31,6 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <errno.h>
 #include <string.h>
 

--- a/src/util/getline.h
+++ b/src/util/getline.h
@@ -1,0 +1,85 @@
+/*-
+ * Copyright (c) 2011 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Christos Zoulas.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+
+ssize_t
+getdelim(char **buf, size_t *bufsiz, int delimiter, FILE *fp)
+{
+	char *ptr, *eptr;
+
+
+	if (*buf == NULL || *bufsiz == 0) {
+		*bufsiz = BUFSIZ;
+		if ((*buf = malloc(*bufsiz)) == NULL)
+			return -1;
+	}
+
+	for (ptr = *buf, eptr = *buf + *bufsiz;;) {
+		int c = fgetc(fp);
+		if (c == -1) {
+			if (feof(fp)) {
+				ssize_t diff = (ssize_t)(ptr - *buf);
+				if (diff != 0) {
+					*ptr = '\0';
+					return diff;
+				}
+			}
+			return -1;
+		}
+		*ptr++ = c;
+		if (c == delimiter) {
+			*ptr = '\0';
+			return ptr - *buf;
+		}
+		if (ptr + 2 >= eptr) {
+			char *nbuf;
+			size_t nbufsiz = *bufsiz * 2;
+			ssize_t d = ptr - *buf;
+			if ((nbuf = realloc(*buf, nbufsiz)) == NULL)
+				return -1;
+			*buf = nbuf;
+			*bufsiz = nbufsiz;
+			eptr = nbuf + nbufsiz;
+			ptr = nbuf + d;
+		}
+	}
+}
+
+ssize_t
+getline(char **buf, size_t *bufsiz, FILE *fp)
+{
+	return getdelim(buf, bufsiz, '\n', fp);
+}

--- a/src/util/platform.c
+++ b/src/util/platform.c
@@ -1,0 +1,416 @@
+#include "platform.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+//////////////////////////////////////////////////////////////////////////////
+// Platform independent implementations
+//////////////////////////////////////////////////////////////////////////////
+
+// Modifies a path in-place to changes slashes to forward slashes only,
+// so it doesn't generate escape sequences in the preprocessor include generator
+char* platform_pathslashes(char* buf) {
+  size_t i;
+  for(i = 0; i < strlen(buf); ++i) {
+    if (buf[i] == '\\') {
+      buf[i] = '/';
+    }
+  }
+  return buf;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Platform specific implementations
+//////////////////////////////////////////////////////////////////////////////
+//
+// Win32
+//
+#ifdef _WIN32
+
+#include <io.h>
+#include <fcntl.h>
+#include <windows.h>
+#include <shlwapi.h>
+#include <process.h>
+
+char* strndup(const char* s1, unsigned long long n) {
+    char* c = (char*)malloc(n + 1);
+    memcpy(c, s1, n);
+    c[n] = 0;
+    return c;
+}
+
+// Creates a temporary file with a given extension and returns the path
+FILE* platform_mktempfile2(const char* ext, char** path, const char* mode) {
+  if (!path) {
+    return NULL;
+  }
+
+  char tp[MAX_PATH + 1];
+  char* fn = strdup("xcc-XXXXXX");
+
+  // Temporary path
+  if (!GetTempPath(sizeof(tp), tp)) {
+    free(fn);
+    return NULL;
+  }
+  tp[MAX_PATH] = 0;
+
+  // Temporary filename
+  mktemp(fn);
+  if (!fn) {
+    return NULL;
+  }
+
+  // Construct full path
+  char fp[MAX_PATH + 1] = { 0 };
+  snprintf(fp, (sizeof(char) * MAX_PATH), "%s%s%s", tp, fn, ext ? ext : "");
+  fp[MAX_PATH] = 0;
+  free(fn);
+
+  *path = strdup(fp);
+
+  // Open file
+  return fopen(fp, mode);
+}
+
+// Opens a temporary file cached by the filesystem, shouldn't normally cache to disk
+FILE* fmemopen(void* buf, size_t len, const char* mode) {
+  // Uses a temporary file to simulate fmemopen, though FILE_ATTRIBUTE_TEMPORARY should keep it cached in RAM
+  // Only supports 'b' in mode
+
+  int fd;
+  FILE *fp;
+  char tp[MAX_PATH - 32];
+  char fn[MAX_PATH + 1];
+  HANDLE h;
+
+  (void)mode;
+
+  if (!GetTempPath(sizeof(tp), tp)) {
+    return NULL;
+  }
+
+  if (!GetTempFileName(tp, "xcc", 0, fn)) {
+    return NULL;
+  }
+
+  h = CreateFile(fn, GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE, NULL);
+  if (INVALID_HANDLE_VALUE == h) {
+    return NULL;
+  }
+
+  fd = _open_osfhandle((intptr_t)h, _O_APPEND);
+  if (fd < 0) {
+    CloseHandle(h);
+    return NULL;
+  }
+
+  if (strchr(mode, 'b') != NULL) {
+    fp = fdopen(fd, "wb+");
+  } else {
+    fp = fdopen(fd, "w+");
+  }
+  if (!fp) {
+    CloseHandle(h);
+    return NULL;
+  }
+
+  if (buf != NULL && len > 0) {
+    fwrite(buf, len, 1, fp);
+    rewind(fp);
+  }
+
+  return fp;
+}
+
+// Creates a temporary file, opens it in write-binary mode
+FILE* platform_mktempfile(void) {
+  // Opens a temporary file in write and binary mode cached by the filesystem, shouldn't normally cache to disk
+  return fmemopen(NULL, 0, "wb");
+}
+
+FILE* open_memstream(char** data, size_t* len) {
+  // Dummy, actually handled in flush_memstream on this platform, and wrap fmemopen instead
+  (void)data;
+  (void)len;
+  // Opens a temporary file in write and binary mode cached by the filesystem, shouldn't normally cache to disk
+  return platform_mktempfile();
+}
+
+// Flushes the temporary file and ensures the data pointer contains a pointer to the contents of the buffer if necessary
+void flush_memstream(FILE* file, char** data, size_t* len) {
+  if (!file || !data || !len) {
+    return;
+  }
+
+  // Get file length
+  if (fseek(file, 0, SEEK_END) != 0) {
+    return;
+  }
+  const size_t file_len = ftell(file);
+
+  // Allocate buffer
+  char* buffer = (char*)malloc(file_len + 1);
+  if (!buffer) {
+    return;
+  }
+
+  // Read entire file into buffer
+  if (fseek(file, 0, SEEK_SET) != 0) {
+    free(buffer);
+    return;
+  }
+  size_t nread = fread(buffer, 1, file_len, file);
+  if (nread != file_len) {
+    free(buffer);
+    return;
+  }
+  buffer[file_len] = 0;
+
+  *data = buffer;
+  *len = file_len;
+}
+
+char* platform_getcwd(char* buf, size_t size) {
+  return getcwd(buf, size);
+}
+
+bool platform_is_fullpath(const char *filename) {
+  return !PathIsRelativeA(filename);
+}
+
+bool platform_is_rootpath(const char* path) {
+  // Returns whether this path originates from the root
+  return platform_is_fullpath(path);
+}
+
+bool platform_cmp_path(const char* str1, const char *str2) {
+  // Consider forward and backward slashes identical
+  while (*str1) {
+    if (!((*str1 == *str2) || (*str1 == '/' && *str2 == '\\') || (*str1 == '\\' && *str2 == '/'))) {
+      return false;
+    }
+    str1++;
+    str2++;
+  }
+  return true;
+}
+
+bool platform_wait_process(pid_t pid, int *result) {
+  if (!result) {
+    return false;
+  }
+  
+  *result = -1;
+  if (!SUCCEEDED(_cwait(result, pid, WAIT_CHILD)))
+    return false;
+  return true;
+}
+
+pid_t platform_wait_process_any(pid_t *pids, size_t pids_len, int *result) {
+  if (!result || !pids_len) {
+    return -1;
+  }
+
+  // pids -> handles
+  HANDLE* handles = (HANDLE*)malloc(sizeof(HANDLE) * pids_len);  
+  if (!handles) {
+    return -1;
+  }
+  memset(handles, 0, sizeof(HANDLE) * pids_len);
+
+  // Wait for any process to signal
+  DWORD res = WaitForMultipleObjects(pids_len, handles, FALSE, INFINITE);
+  if (/*res >= WAIT_OBJECT_0 &&*/ res < (WAIT_OBJECT_0 + pids_len)) {
+    DWORD dwResult = 0;
+    GetExitCodeProcess(handles[res - WAIT_OBJECT_0], &dwResult);
+    *result = dwResult;
+    free(handles);
+    return pids[res - WAIT_OBJECT_0];
+  }
+
+  // Failure
+  free(handles);
+  return -1;
+}
+
+int platform_spawnvp(const char* cname, const char* const* argv, const int handle_in, const int handle_out, const int handle_err) {
+    int ret;
+    STARTUPINFO StartupInfo;
+    PROCESS_INFORMATION ProcessInformation;
+    char *cmd;
+    size_t clen = 0;
+
+    // Count number of argv elements by using NULL terminator
+    while(argv[clen] != NULL) {
+      ++clen;
+    }
+    if (clen < 1) {
+      // At least one argument (program name) required
+      return -1;
+    }
+
+    // Join argv into full command line string
+    {
+      // Calculate total string length
+      size_t total_length = 0;
+      for (size_t i = 0; i < clen; ++i) {
+        total_length += strlen(argv[i]);
+      }
+
+      // Add spaces (except last) and terminator
+      total_length += (clen - 1) + 1;
+
+      // Allocate
+      cmd = (char*)malloc(total_length * sizeof(char));
+      if (cmd == NULL) {
+        return -1;
+      }
+      cmd[0] = 0;
+
+      // Concatenate
+      for (size_t i = 0; i < clen; ++i) {
+        strcat(cmd, argv[i]);
+        if (i < (clen - 1)) {
+          strcat(cmd, " ");
+        }
+      }
+    }
+
+    memset(&StartupInfo, 0, sizeof(StartupInfo));
+    StartupInfo.cb = sizeof(StartupInfo);
+    StartupInfo.wShowWindow = FALSE;
+    StartupInfo.hStdInput = handle_in != -1 ? (HANDLE)_get_osfhandle(handle_in) : GetStdHandle(STD_INPUT_HANDLE);
+    StartupInfo.hStdOutput  = handle_out != -1 ? (HANDLE)_get_osfhandle(handle_out) : GetStdHandle(STD_OUTPUT_HANDLE);
+    StartupInfo.hStdError = handle_err != -1 ? (HANDLE)_get_osfhandle(handle_err) : GetStdHandle(STD_ERROR_HANDLE);
+    if (!(StartupInfo.hStdInput == INVALID_HANDLE_VALUE &&
+        StartupInfo.hStdOutput == INVALID_HANDLE_VALUE &&
+        StartupInfo.hStdError == INVALID_HANDLE_VALUE))
+    {
+        StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
+    }
+    if (!CreateProcess(cname,   /* search PATH to find executable */
+                       cmd,   /* executable, and its arguments */
+                       NULL,    /* process attributes */
+                       NULL,    /* thread attributes */
+                       TRUE,    /* inherit handles */
+                       CREATE_NO_WINDOW,    /* creation flags */
+                       NULL, /* inherit environment */
+                       NULL,   /* inherit cwd */
+                       &StartupInfo,
+                       &ProcessInformation))
+    {
+      return -1;
+    }
+    ret = (int)ProcessInformation.dwProcessId;
+    CloseHandle(ProcessInformation.hThread);
+    free(cmd);
+    return ret;
+}
+
+void platform_kill(int pid) {
+  HANDLE handle = OpenProcess(PROCESS_TERMINATE, FALSE, (DWORD)pid);
+  if (handle == NULL) {
+    // Failure
+    return;
+  }
+  TerminateProcess(handle, 1);
+}
+
+#else
+//////////////////////////////////////////////////////////////////////////////
+// Platform specific implementations
+//////////////////////////////////////////////////////////////////////////////
+//
+// POSIX
+//
+#include <unistd.h>
+
+// Creates a temporary file with a given extension and returns the path
+FILE* platform_mktempfile2(const char* ext, char** path, const char* mode) {
+  if (!path) {
+    return NULL;
+  }
+
+  // Construct full path template
+  const size_t MAX_PATH = 255;
+  char fp[MAX_PATH + 1];
+  snprintf(fp, (sizeof(char) * MAX_PATH), "/tmp/xcc-XXXXXX%s", ext ? ext : "");
+  fp[MAX_PATH] = 0;
+
+  // Create temporary file
+  int fd = mkstemps(fp, ext ? strlen(ext) : 0);
+  *path = strdup(fp);
+  return fdopen(fd, mode);
+}
+
+// Creates a temporary file, opens it in write-binary mode
+FILE* platform_mktempfile(void) {
+  return tmpfile();
+}
+
+// Flushes the temporary file and ensures the data pointer contains a pointer to the contents of the buffer if necessary
+void flush_memstream(FILE* file, char** data, size_t* len) {
+  (void)file;
+  (void)data;
+  (void)len;
+  // This function is a nop because on POSIX, the memstream does this on open
+}
+
+char* platform_getcwd(char* buf, size_t size) {
+  return getcwd(buf, size);
+}
+
+bool platform_is_fullpath(const char* filename) {
+  // Path without any .. operators
+  if (*filename != '/')
+    return false;
+  for (const char *p = filename;;) {
+    p = strstr(p, "/..");
+    if (p == NULL)
+      return true;
+    if (p[3] == '/' || p[3] == '\0')
+      return false;
+    p += 3;
+  }
+}
+
+bool platform_is_rootpath(const char* path) {
+  // Returns whether this path originates from the root
+  return *path == '/';
+}
+
+bool platform_cmp_path(const char* a, const char* b) {
+  return strcmp(a, b) == 0;
+}
+
+// Unsupported functions for WASM targets
+#ifndef __WASM
+#include <signal.h>
+#include <sys/wait.h>
+
+bool platform_wait_process(pid_t pid, int* result) {
+  if (waitpid(pid, result, 0) < 0) {
+    return false;
+  }
+  return true;
+}
+
+pid_t platform_wait_process_any(pid_t* pids, size_t pids_len, int* result) {
+  (void)pids;
+  (void)pids_len;
+
+  // Assumes all processes have been forked, so waitpid will do
+  *result = -1;
+  return waitpid(0, result, 0);
+}
+
+void platform_kill(int pid) {
+  kill(pid, SIGKILL);
+}
+
+#endif
+
+#endif

--- a/src/util/platform.h
+++ b/src/util/platform.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+//////////////////////////////////////////////////////////////////////////////
+// Platform independent implementations
+//////////////////////////////////////////////////////////////////////////////
+
+// Modifies a path in-place to changes slashes to forward slashes only,
+// so it doesn't generate escape sequences in the preprocessor include generator
+char* platform_pathslashes(char* buf);
+
+// Creates a temporary file with a given extension, opens it in write-binary mode, returns the path
+FILE* platform_mktempfile2(const char* ext, char** path, const char* mode);
+
+// Creates a temporary file, opens it in write-binary mode
+FILE* platform_mktempfile(void);
+
+// Flushes the temporary file and ensures the data pointer contains a pointer to the contents of the buffer if necessary
+void flush_memstream(FILE* file, char** data, size_t* len);
+
+char* platform_getcwd(char* buf, size_t size);
+bool platform_is_fullpath(const char* path);
+bool platform_is_rootpath(const char* path);
+bool platform_cmp_path(const char* a, const char* b);
+
+bool platform_wait_process(pid_t pid, int* result);
+pid_t platform_wait_process_any(pid_t *pids, size_t pids_len, int* result);
+
+void platform_kill(int pid);
+
+//////////////////////////////////////////////////////////////////////////////
+// Platform specific implementations
+//////////////////////////////////////////////////////////////////////////////
+//
+// Win32
+//
+#ifdef _WIN32
+
+#include <sys/stat.h>
+
+// Replacements
+FILE* fmemopen(void* buf, size_t len, const char* mode);
+FILE* open_memstream(char** data, size_t* len);
+char* strndup(const char* s1, unsigned long long n);
+
+int platform_spawnvp(const char* cname, const char* const* argv, const int handle_in, const int handle_out, const int handle_err);
+
+#endif

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -295,15 +295,15 @@ void show_error_line(const char *line, const char *p, int len) {
 }
 
 bool is_im8(intptr_t x) {
-  return x <= ((1L << 7) - 1) && x >= -(1L << 7);
+  return x <= ((1LL << 7) - 1) && x >= -(1LL << 7);
 }
 
 bool is_im16(intptr_t x) {
-  return x <= ((1L << 15) - 1) && x >= -(1L << 15);
+  return x <= ((1LL << 15) - 1) && x >= -(1LL << 15);
 }
 
 bool is_im32(intptr_t x) {
-  return x <= ((1L << 31) - 1) && x >= -(1L << 31);
+  return x <= ((1LL << 31) - 1) && x >= -(1LL << 31);
 }
 
 const char *skip_whitespaces(const char *s) {

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -11,6 +11,11 @@
 #include "../version.h"
 #include "table.h"
 
+#ifdef _WIN32
+// Requires implementation of getline
+#include "getline.h"
+#endif
+
 int isalnum_(int c) {
   return isalnum(c) || c == '_';
 }

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -4,9 +4,11 @@
 
 #include <stdbool.h>
 #include <stddef.h>  // size_t
-#include <stdint.h>  // intptr_t
 #include <stdio.h>  // FILE
 #include <sys/types.h>  // ssize_t
+#include <stdint.h>
+
+#include "../config.h"
 
 #define MIN(a, b)  ((a) < (b) ? (a) : (b))
 #define MAX(a, b)  ((a) > (b) ? (a) : (b))

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -3,12 +3,15 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <stddef.h>  // size_t
 #include <stdio.h>  // FILE
 #include <sys/types.h>  // ssize_t
 #include <stdint.h>
 
 #include "../config.h"
+
+#include "platform.h" // platform specifics
 
 #define MIN(a, b)  ((a) < (b) ? (a) : (b))
 #define MAX(a, b)  ((a) > (b) ? (a) : (b))

--- a/src/wcc/gen_wasm.c
+++ b/src/wcc/gen_wasm.c
@@ -1883,7 +1883,7 @@ static Expr *proc_builtin_nan(const Token *ident) {
     parse_error(PE_NOFATAL, fmt->token, "String literal expected");
   }
 
-  const uint64_t MASK = (1UL << 52) - 1UL;
+  const uint64_t MASK = (1ULL << 52) - 1ULL;
   union { double d; uint64_t q; } u;
   u.d = NAN;
   u.q = (u.q & ~MASK) | (significand & MASK);

--- a/src/wcc/gen_wasm.c
+++ b/src/wcc/gen_wasm.c
@@ -1,7 +1,6 @@
 #include "../config.h"
 #include "wcc.h"
 
-#include <alloca.h>
 #include <assert.h>
 #include <limits.h>
 #include <stdio.h>

--- a/src/wcc/traverse.c
+++ b/src/wcc/traverse.c
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include <stdlib.h>  // malloc
 #include <string.h>  // memcpy
+#include <inttypes.h> // PRIx64
 
 #include "ast.h"
 #include "fe_misc.h"  // curscope
@@ -858,7 +859,7 @@ void traverse_ast(Vector *decls) {
         info->non_prim.address = address;
         size_t size = type_size(varinfo->type);
         address += size;
-        VERBOSE("%04x: %.*s  (size=0x%lx)\n", info->non_prim.address, NAMES(varinfo->name), size);
+        VERBOSE("%04x: %.*s  (size=0x%" PRIx64 ")\n", info->non_prim.address, NAMES(varinfo->name), (uint64_t)size);
       }
     }
   }

--- a/src/wcc/wasm_linker.c
+++ b/src/wcc/wasm_linker.c
@@ -1,7 +1,7 @@
 #include "../config.h"
 #include "wasm_linker.h"
 
-#include <ar.h>
+#include "../ar/ar.h"
 #include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,6 +12,7 @@ CFLAGS:=-ansi -std=c11 -Wall -Wextra -Werror \
 	-Wno-empty-body
 CFLAGS+=-I$(CC1_FE_DIR) -I$(UTIL_DIR)
 CFLAGS+=-D_POSIX_C_SOURCE=200809L  # for getline
+CFLAGS+=-D_DEFAULT_SOURCE # mkstemps
 
 PREFIX:=
 XCC:=../$(PREFIX)xcc
@@ -109,8 +110,8 @@ test-link:
 endif
 
 INITIALIZER_SRCS:=initializer_test.c $(CC1_FE_DIR)/parser.c $(CC1_FE_DIR)/parser_expr.c $(CC1_FE_DIR)/lexer.c \
-	$(CC1_FE_DIR)/initializer.c $(CC1_FE_DIR)/fe_misc.c $(CC1_FE_DIR)/var.c $(CC1_FE_DIR)/type.c $(CC1_FE_DIR)/ast.c $(UTIL_DIR)/util.c $(UTIL_DIR)/table.c \
-	$(DEBUG_DIR)/dump_expr.c
+	$(CC1_FE_DIR)/initializer.c $(CC1_FE_DIR)/fe_misc.c $(CC1_FE_DIR)/var.c $(CC1_FE_DIR)/type.c $(CC1_FE_DIR)/ast.c $(UTIL_DIR)/util.c \
+	$(UTIL_DIR)/platform.c $(UTIL_DIR)/table.c $(DEBUG_DIR)/dump_expr.c
 initializer_test:	$(INITIALIZER_SRCS)
 	$(CC) -o$@ -DNO_MAIN_DUMP_EXPR $(CFLAGS) $^
 
@@ -118,13 +119,13 @@ TABLE_SRCS:=table_test.c $(UTIL_DIR)/table.c
 table_test:	$(TABLE_SRCS)
 	$(CC) -o$@ $(CFLAGS) $^
 
-UTIL_SRCS:=util_test.c $(UTIL_DIR)/util.c $(UTIL_DIR)/table.c
+UTIL_SRCS:=util_test.c $(UTIL_DIR)/util.c $(UTIL_DIR)/platform.c $(UTIL_DIR)/table.c
 util_test:	$(UTIL_SRCS)
 	$(CC) -o$@ $(CFLAGS) $^
 
 PARSER_SRCS:=parser_test.c $(CC1_FE_DIR)/parser_expr.c $(CC1_FE_DIR)/lexer.c $(CC1_FE_DIR)/parser.c \
 	$(CC1_FE_DIR)/initializer.c $(CC1_FE_DIR)/fe_misc.c $(CC1_FE_DIR)/type.c $(CC1_FE_DIR)/ast.c $(CC1_FE_DIR)/var.c \
-	$(UTIL_DIR)/util.c $(UTIL_DIR)/table.c
+	$(UTIL_DIR)/util.c $(UTIL_DIR)/platform.c $(UTIL_DIR)/table.c
 parser_test:	$(PARSER_SRCS)
 	$(CC) -o$@ $(CFLAGS) $^
 
@@ -138,7 +139,7 @@ dvaltest:	$(FVAL_SRCS) flotest.inc # $(XCC)
 fvaltest:	$(FVAL_SRCS) flotest.inc # $(XCC)
 	$(XCC) -o$@ -Werror -DUSE_SINGLE $(FVAL_SRCS)
 
-TYPE_SRCS:=print_type_test.c $(CC1_FE_DIR)/type.c $(UTIL_DIR)/util.c $(UTIL_DIR)/table.c
+TYPE_SRCS:=print_type_test.c $(CC1_FE_DIR)/type.c $(UTIL_DIR)/util.c $(UTIL_DIR)/platform.c $(UTIL_DIR)/table.c
 print_type_test:	$(TYPE_SRCS)
 	$(CC) -o $@ $(CFLAGS) $^
 


### PR DESCRIPTION
Implements #156.

Requires MinGW64 MSYS as toolchain.

Notes:
* Relies on #158 (`long` types are 32-bit, not 64-bit on Win32).
* Adds two new vendor files from NetBSD (with permissive BSD license): `ar.h` and `getline.h`.
* Moves most platform specifics into `platform.c` and `platform.h`.

Passes `test-wcc` and `test-wcc-gen2` tests on Win32.