### PR TITLE
Handle relocation for the target architecture only

### DIFF
--- a/include/inttypes.h
+++ b/include/inttypes.h
@@ -5,12 +5,18 @@
 
 #if defined(__ILP32__)
 
+#define PRId32  "ld"
+#define PRIu32  "lu"
+#define PRIx32  "lx"
 #define PRId64  "lld"
 #define PRIu64  "llu"
 #define PRIx64  "llx"
 
 #elif defined(__LP64__)
 
+#define PRId32  "d"
+#define PRIu32  "u"
+#define PRIx32  "x"
 #define PRId64  "ld"
 #define PRIu64  "lu"
 #define PRIx64  "lx"

--- a/src/cc/frontend/fe_misc.c
+++ b/src/cc/frontend/fe_misc.c
@@ -755,15 +755,7 @@ Expr *extract_bitfield_value(Expr *src, const MemberInfo *minfo) {
     tmp = new_expr_bop(EX_BITAND, tmp->type, tmp->token, tmp,
                        new_expr_fixlit(tmp->type, tmp->token, mask));
   } else {
-#if XCC_TARGET_ARCH == XCC_ARCH_RISCV64
-    const unsigned int MINREGSIZE = 8;
     int w = MAX(type_size(type), MINREGSIZE) * TARGET_CHAR_BIT;
-#elif XCC_TARGET_ARCH == XCC_ARCH_AARCH64 || XCC_TARGET_ARCH == XCC_ARCH_WASM
-    const unsigned int MINREGSIZE = 4;
-    int w = MAX(type_size(type), MINREGSIZE) * TARGET_CHAR_BIT;
-#else
-    int w = type_size(type) * TARGET_CHAR_BIT;
-#endif
     int l = w - (minfo->bitfield.position + minfo->bitfield.width);
     tmp = src;
     if (l > 0)

--- a/src/config.h
+++ b/src/config.h
@@ -85,11 +85,21 @@
 #error "Unsupported programming model"
 #endif
 
-// Elf
+//
+
 #if XCC_TARGET_ARCH == XCC_ARCH_X64
 #define MACHINE_TYPE  EM_X86_64
+#define MINREGSIZE  (1)
+
 #elif XCC_TARGET_ARCH == XCC_ARCH_AARCH64
 #define MACHINE_TYPE  EM_AARCH64
+#define MINREGSIZE  (4)
+
 #elif XCC_TARGET_ARCH == XCC_ARCH_RISCV64
 #define MACHINE_TYPE  EM_RISCV
+#define MINREGSIZE  (8)
+
+#elif XCC_TARGET_ARCH == XCC_ARCH_WASM
+#define MINREGSIZE  (4)
+
 #endif

--- a/src/ld/ld.c
+++ b/src/ld/ld.c
@@ -3,6 +3,7 @@
 #include <ar.h>
 #include <assert.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -95,11 +96,13 @@ typedef struct {
   int nfiles;
   uintptr_t offsets[SEC_COUNT];
   Vector *progbit_sections[SEC_COUNT];
+  int error_count;
 } LinkEditor;
 
 void ld_init(LinkEditor *ld, int nfiles) {
   ld->files = calloc_or_die(sizeof(*ld->files) * nfiles);
   ld->nfiles = nfiles;
+  ld->error_count = 0;
 
   for (int secno = 0; secno < SEC_COUNT; ++secno) {
     ld->offsets[secno] = 0;
@@ -261,11 +264,7 @@ static void resolve_rela_elfobj(LinkEditor *ld, ElfObj *elfobj) {
       void *p = dst_info->progbits.content + rela->r_offset;
       uintptr_t pc = elfobj->section_infos[shdr->sh_info].progbits.address + rela->r_offset;
       switch (ELF64_R_TYPE(rela->r_info)) {
-#if XCC_TARGET_ARCH == XCC_ARCH_RISCV64
-      case R_RISCV_64:
-        *(uint64_t*)p = address;
-        break;
-#else
+#if XCC_TARGET_ARCH == XCC_ARCH_X64
       case R_X86_64_64:
         *(uint64_t*)p = address;
         break;
@@ -273,8 +272,8 @@ static void resolve_rela_elfobj(LinkEditor *ld, ElfObj *elfobj) {
       case R_X86_64_PLT32:
         *(uint32_t*)p = address - pc;
         break;
-#endif
 
+#elif XCC_TARGET_ARCH == XCC_ARCH_AARCH64
       case R_AARCH64_ABS64:
         *(uint64_t*)p = address;
         break;
@@ -304,6 +303,10 @@ static void resolve_rela_elfobj(LinkEditor *ld, ElfObj *elfobj) {
         assert(!"TODO: Implement");
         break;
 
+#elif XCC_TARGET_ARCH == XCC_ARCH_RISCV64
+      case R_RISCV_64:
+        *(uint64_t*)p = address;
+        break;
       case R_RISCV_CALL:
         {
           int64_t offset = address - pc;
@@ -399,8 +402,12 @@ static void resolve_rela_elfobj(LinkEditor *ld, ElfObj *elfobj) {
           }
         }
         break;
+#endif
 
-      default: assert(false); break;
+      default:
+        fprintf(stderr, "Unhandled rela type: %" PRIx32 "\n", (uint32_t)ELF64_R_TYPE(rela->r_info));
+        ++ld->error_count;
+        break;
       }
     }
   }
@@ -592,6 +599,8 @@ bool ld_link(LinkEditor *ld, Table *unresolved, uintptr_t start_address) {
   }
 
   resolve_relas(ld);
+  if (ld->error_count > 0)
+    return false;
 
   for (int i = 0; i < ld->nfiles; ++i) {
     File *file = &ld->files[i];


### PR DESCRIPTION
To avoid compilation errors, only handle relocations for the target architecture.

#162
