### PR TITLE
Export option help

### DIFF
--- a/src/wcc/wcc.c
+++ b/src/wcc/wcc.c
@@ -590,6 +590,12 @@ int main(int argc, char *argv[]) {
     .nostdinc = false,
   };
   parse_options(argc, argv, &opts);
+  
+  // when given -c and -e, treat as OutExecutable && entry_point, since otherwise exports wont be generated
+  if (opts.entry_point == NULL && opts.exports->len != 0 && opts.out_type == OutObject) {
+    opts.entry_point = "";
+    opts.out_type = OutExecutable;
+  }
 
   if (opts.sources->len == 0) {
     fprintf(stderr, "No input files\n\n");


### PR DESCRIPTION
This is a bit unclean; after optargs are parsed, effectively if it sees "-c" "-e" (and no entrypoint), it converts it into "--entry-point=" "-e" (and no "-c" option). But I think the resulting behavior exactly matches user expectation now. 

Once I learn the codebase better, I might be able to provide a better proposal. 