### PR TITLE
add env name to linker, fix typo

### DIFF
--- a/src/wcc/wasm_linker.c
+++ b/src/wcc/wasm_linker.c
@@ -757,6 +757,7 @@ static bool resolve_symbols(WasmLinker *linker) {
 
   // Enumerate unresolved: import
   const Name *wasi_module_name = alloc_name(WASI_MODULE_NAME, NULL, false);
+  const Name *wasm_module_name = alloc_name("env", NULL, false);
   uint32_t unresolved_func_count = 0;
   const Name *name;
   SymbolInfo *sym;
@@ -769,7 +770,8 @@ static bool resolve_symbols(WasmLinker *linker) {
     switch (sym->kind) {
     default: assert(false); // Fallthrough to suppress warning.
     case SIK_SYMTAB_FUNCTION:
-      if (sym->module_name != NULL && equal_name(sym->module_name, wasi_module_name)) {
+      if (sym->module_name != NULL && (equal_name(sym->module_name, wasi_module_name) ||
+                                       equal_name(sym->module_name, wasm_module_name))) {
         sym->combined_index = unresolved_func_count++;
         break;
       }

--- a/src/wcc/wcc.c
+++ b/src/wcc/wcc.c
@@ -58,7 +58,7 @@ static void usage(FILE *fp) {
       "  -D <label[=value]>    Define label\n"
       "  -o <filename>         Set output filename (Default: a.wasm)\n"
       "  -c                    Output object file\n"
-      "  --entry-point=<name>  Specify entry point (Defulat: _start)\n"
+      "  --entry-point=<name>  Specify entry point (Default: _start)\n"
       "  --stack-size=<size>   Output object file (Default: 8192)\n"
   );
 }


### PR DESCRIPTION
Hi I wanted to use wcc for targetting wasm directly without emcc/wasi and this was breaking it.