### PR TITLE
fix buffer overflow

### DIFF
--- a/src/util/util.c
+++ b/src/util/util.c
@@ -244,7 +244,7 @@ char *change_ext(const char *path, const char *ext) {
   const char *q = strrchr(p, '.');
   size_t len = q != NULL ? (size_t)(q - path) : strlen(path);
   size_t ext_len = strlen(ext);
-  char *s = malloc(len + 1 + ext_len);
+  char *s = malloc(len + 1 + ext_len + 1);
   if (s != NULL) {
     memcpy(s, path, len);
     s[len] = '.';


### PR DESCRIPTION
Found this while building pdclib for wasm, also I got doom booting in browser using wcc 
<img width="716" height="148" alt="image" src="https://github.com/user-attachments/assets/26a34b42-1e9c-4fec-9089-22e6d0b25ea2" />

I already got it all working with clang on my project, but for some reason wcc is giving me a bunch of random errors like these 
<img width="606" height="65" alt="image" src="https://github.com/user-attachments/assets/e151bb8a-3bbe-4a66-a4db-5664e66fb703" />

I see there's a PR for goto I might wait try that as this might be caused by me messing up gotos with a define in pdclib...