### PR TITLE
Treated as imported symbol if import_name is specified

### DIFF
--- a/src/wcc/emit_wasm.c
+++ b/src/wcc/emit_wasm.c
@@ -598,12 +598,17 @@ static void emit_linking_section(EmitWasm *ew) {
         flags |= WASM_SYM_BINDING_LOCAL | WASM_SYM_VISIBILITY_HIDDEN;
       if (info->flag & FF_WEAK)
         flags |= WASM_SYM_BINDING_WEAK;
+      if (info->flag & FF_IMPORT_NAME) {
+        // __attribute((import_name("..."))) is specified:
+        flags |= WASM_SYM_EXPLICIT_NAME;
+      }
 
       data_push(&linking_section, SIK_SYMTAB_FUNCTION);  // kind
       data_uleb128(&linking_section, -1, flags);
       data_uleb128(&linking_section, -1, info->index);
 
-      if (info->func != NULL) {  // Defined function: put name. otherwise not required.
+      if (info->func != NULL ||  // Defined function: put name. otherwise not required.
+          flags & WASM_SYM_EXPLICIT_NAME) {
         data_string(&linking_section, name->chars, name->bytes);
       }
       ++count;

--- a/src/wcc/traverse.c
+++ b/src/wcc/traverse.c
@@ -110,10 +110,12 @@ static FuncInfo *register_func_info(const Name *funcname, Function *func, VarInf
     }
     if (table_try_get(attributes, alloc_name("import_name", NULL, false), (void**)&params)) {
       const Token *token = params->len > 0 ? params->data[0] : NULL;
-      if (params->len != 1 && token->kind != TK_STR)
+      if (params->len != 1 && token->kind != TK_STR) {
         parse_error(PE_NOFATAL, token, "import_name: string expected");
-      else
+      } else {
         info->func_name = alloc_name(token->str.buf, token->str.buf + token->str.len - 1, false);
+        info->flag |= FF_IMPORT_NAME;
+      }
     }
     if (table_try_get(attributes, alloc_name("weak", NULL, false), (void**)&params))
       info->flag |= FF_WEAK;

--- a/src/wcc/wasm_linker.h
+++ b/src/wcc/wasm_linker.h
@@ -12,6 +12,7 @@ typedef struct Vector Vector;
 #define WASI_MODULE_NAME  "wasi_snapshot_preview1"
 
 typedef struct {
+  const char *import_module_name;
   bool allow_undefined;
   bool export_all;
 } WasmLinkerOptions;

--- a/src/wcc/wcc.c
+++ b/src/wcc/wcc.c
@@ -39,7 +39,6 @@ typedef struct {
   Vector *sources;
   const char *root;
   const char *ofn;
-  const char *import_module_name;
   const char *entry_point;
   enum OutType out_type;
   enum SourceType src_type;
@@ -226,7 +225,7 @@ int compile_csource(const char *src, const char *ofn, Vector *obj_files, Options
   if (ofp == NULL) {
     error("Cannot open output file");
   } else {
-    emit_wasm(ofp, opts->import_module_name, exports);
+    emit_wasm(ofp, opts->linker_opts.import_module_name, exports);
     assert(compile_error_count == 0);
     fclose(ofp);
   }
@@ -467,7 +466,7 @@ static void parse_options(int argc, char *argv[], Options *opts) {
       }
       break;
     case OPT_IMPORT_MODULE_NAME:
-      opts->import_module_name = optarg;
+      opts->linker_opts.import_module_name = optarg;
       break;
     case OPT_VERBOSE:
       verbose = true;
@@ -722,7 +721,6 @@ int main(int argc, char *argv[]) {
     .sources = new_vector(),
     .root = root,
     .ofn = NULL,
-    .import_module_name = DEFAULT_IMPORT_MODULE_NAME,
     .entry_point = NULL,
     .out_type = OutExecutable,
     .src_type = UnknownSource,
@@ -730,6 +728,9 @@ int main(int argc, char *argv[]) {
     .nodefaultlibs = false,
     .nostdlib = false,
     .nostdinc = false,
+    .linker_opts = {
+      .import_module_name = DEFAULT_IMPORT_MODULE_NAME,
+    },
   };
   parse_options(argc, argv, &opts);
 

--- a/src/wcc/wcc.h
+++ b/src/wcc/wcc.h
@@ -34,6 +34,7 @@ extern Vector *functypes;  // <DataStorage*>
 #define FF_INLINING  (1 << 2)
 #define FF_WEAK      (1 << 3)
 #define FF_STACK_MODIFIED  (1 << 4)
+#define FF_IMPORT_NAME     (1 << 5)
 
 typedef struct {
   Function *func;


### PR DESCRIPTION
#205

@lesleyrs Would you take a look this PR? Thanks.

With this change, symbols specified by `import_name` are considered to be provided at runtime,
which partially resolves issue 205.
