### PR TITLE
for OPTIMIZE="-O0 -g3" on wcc clang-19

### DIFF
--- a/src/wcc/wasm_linker.c
+++ b/src/wcc/wasm_linker.c
@@ -1291,7 +1291,7 @@ static void out_function_section(WasmLinker *linker) {
   }
 }
 
-inline bool funcref_table_exist(WasmLinker *linker) {
+static inline bool funcref_table_exist(WasmLinker *linker) {
   return table_try_get(&linker->defined, linker->indirect_function_table_name, NULL);
 }
 


### PR DESCRIPTION
and avoiding `undefined reference to 'funcref_table_exist'` in wasm_linker.o