### PR TITLE
Suppress flattening twice for compound literal initializer

### DIFF
--- a/src/cc/frontend/initializer.c
+++ b/src/cc/frontend/initializer.c
@@ -497,11 +497,9 @@ static void flatten_initializer_single(Expr *value) {
 
   case EX_COMPLIT:
     {
-      Initializer *init = flatten_initializer(value->type, value->complit.original_init);
-      value->complit.original_init = init;
-
       Expr *var = value->complit.var;
       if (is_global_scope(var->var.scope)) {
+        Initializer *init = value->complit.original_init;  // Suppose already flattened.
         assert(init->kind == IK_MULTI);
         VarInfo *varinfo = scope_find(var->var.scope, var->var.name, NULL);
         assert(varinfo != NULL);

--- a/src/cc/frontend/parser_expr.c
+++ b/src/cc/frontend/parser_expr.c
@@ -133,18 +133,17 @@ static Expr *parse_compound_literal(Type *type) {
 
   if (type->kind == TY_ARRAY)
     type = fix_array_size(type, init, token);
+  init = flatten_initializer(type, init);
 
   Expr *var = alloc_tmp_var(curscope, type);
   Vector *inits = NULL;
   if (is_global_scope(curscope)) {
-    // Global variable initializer is flattened in `check_vardecl()`
     const Name *name = var->var.name;
     VarInfo *varinfo = scope_find(curscope, name, NULL);
     assert(varinfo != NULL);
     varinfo->storage |= VS_STATIC;
     varinfo->global.init = init;
   } else {
-    init = flatten_initializer(type, init);
     inits = assign_initial_value(var, init, NULL);
   }
 

--- a/tests/valtest.c
+++ b/tests/valtest.c
@@ -2000,6 +2000,15 @@ TEST(initializer) {
     struct T {char *str;};
     struct T *t = &(struct T){"xyz"};
     EXPECT_STREQ("String in initializer with compound literal", "xyz", t->str);
+
+    struct U {
+      union {
+        struct {int x;} a;
+        struct {int y;} b;
+      } u;
+    };
+    struct U u = (struct U){.u.b = {369}};
+    EXPECT("Initializer with compound literal contains union", 369, u.u.b.y);
   }
 }
 


### PR DESCRIPTION
@osa1 Would you please take a look this change fixes #240 ? Thanks.
